### PR TITLE
UserDaemon: Implement `closeOpenedApps` for `toLogin`

### DIFF
--- a/src/apps/user/iconeditor/runtime.ts
+++ b/src/apps/user/iconeditor/runtime.ts
@@ -76,6 +76,7 @@ export class IconEditorRuntime extends AppProcess {
 
   async save() {
     this.iconService?.Configuration.set({ ...this.icons() });
+    this.hasChanges.set(false);
     this.closeWindow();
     this.userDaemon?.restart();
   }

--- a/src/ts/apps/process.ts
+++ b/src/ts/apps/process.ts
@@ -122,11 +122,13 @@ export class AppProcess extends Process {
   async closeWindow(kill = true) {
     this.Log(`Closing window ${this.pid}`);
 
+    this.handler.renderer?.focusedPid.set(this.pid);
+
     const canClose = this._disposed || (await this.onClose());
 
     if (!canClose) {
       this.Log(`Can't close`);
-      return;
+      return false;
     }
 
     this.shell?.trayHost?.disposeProcessTrayIcons?.(this.pid);
@@ -156,6 +158,8 @@ export class AppProcess extends Process {
       if (!this.app.data.core) await Sleep(400);
       await this.killSelf();
     }
+
+    return true;
   }
 
   render(args: RenderArgs): any {

--- a/src/ts/kernel/mods/stack.ts
+++ b/src/ts/kernel/mods/stack.ts
@@ -212,7 +212,7 @@ export class ProcessHandler extends KernelModule {
         continue;
       }
 
-      await this.kill(pid);
+      await this.kill(pid, force);
     }
   }
 


### PR DESCRIPTION
This new method properly handles the closing of regular application windows before allowing the toLogin operation to proceed. If aborted, a notification appears informing the user of the application that interrupted the toLogin call, so that they may properly exit the relevant app and try again.