### PR TITLE
Fix battery info being undefined when charging on laptops

### DIFF
--- a/src/ts/server/user/daemon.ts
+++ b/src/ts/server/user/daemon.ts
@@ -390,7 +390,7 @@ export class UserDaemon extends Process {
     if (!navigator.getBattery) return undefined;
 
     const info = (await navigator.getBattery()) as BatteryType;
-    if (info.charging && info.dischargingTime === Infinity) return undefined;
+    if (info.charging && info.level === 1) return undefined;
 
     return info;
   }


### PR DESCRIPTION
Fixes #145 

NOTE: slight side effect is that if it's fully charged (100%) but still plugged in (`charging === true && level === 1`), It will not return battery info. This is the best way I know of to do this because there is no web standard to let us know if there is a battery.