### PR TITLE
Configuration stuff

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,3 +26,5 @@ jobs:
         run: yarn console:check
       - name: Check lifecycle regions
         run: yarn region:check
+      - name: Check method count
+        run: yarn method:check

--- a/.gitignore
+++ b/.gitignore
@@ -13,8 +13,6 @@ dist-ssr
 *.local
 
 # Editor directories and files
-.vscode/*
-!.vscode/extensions.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Debug ArcOS in Chrome",
+      "url": "http://localhost:5173",
+      "webRoot": "${workspaceFolder}"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build:nogit:nominify": "vite build --minify false",
     "region:check": "node tools/validate-regions.mjs",
     "console:check": "node tools/console-usage.mjs",
-    "check:everything": "yarn run check && yarn console:check && yarn region:check"
+    "method:check": "node tools/check-params.mjs",
+    "check:everything": "yarn run check && yarn console:check && yarn region:check && yarn method:check"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "5.1.0",


### PR DESCRIPTION
I'll make some articles regarding development but a personal recommendation is to install and configure VS Code for Vite by Anthony Fu to get easy vite launching inside of vscode, I have it set up to launch in the background on port 5173 (no autostart when I start vscode) which is also what port the launch config points to

https://marketplace.visualstudio.com/items?itemName=antfu.vite